### PR TITLE
Fixed wrong usage of the ternary operator

### DIFF
--- a/src/Command/Task/ListCommand.php
+++ b/src/Command/Task/ListCommand.php
@@ -63,7 +63,7 @@ EOF
             $tableHelper->addRow(
                 [
                     $service->getName(),
-                    $service->getDescription() !== '' ?: 'No Description'
+                    $service->getDescription() !== '' ? $service->getDescription() : 'No Description'
                 ]
             );
         }


### PR DESCRIPTION
`$service->getDescription() !== '' ?: 'No Description'`

Means use the result of `$service->getDescription() !== ''` if it is not a falsey value or use `'No Description'` otherwise.

The result of `$service->getDescription() !== ''` is `1`, so `1` gets printed:

```
$ vendor/bin/bldr task:list
+-------------------+-------------+
| Name              | Description |
+-------------------+-------------+
| exec              | 1           |
| apply             | 1           |
| background        | 1           |
| filesystem:remove | 1           |
| filesystem:mkdir  | 1           |
| filesystem:touch  | 1           |
| filesystem:dump   | 1           |
| notify            | 1           |
| watch             | 1           |
| mysql:user        | 1           |
| sleep             | 1           |
| service           | 1           |
+-------------------+-------------+
```
