### PR TITLE
Improved travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,24 @@ php:
     - 5.5
     - 5.6
     - hhvm
+    
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache
 
 matrix:
     allow_failures:
         - php: hhvm
+    include:
+        - php: 5.4
+          env: DEPENDENCIES=low
 
 before_script:
-    - composer install
-    - composer require satooshi/php-coveralls:dev-master --no-progress --prefer-source
+    - composer require satooshi/php-coveralls:dev-master --no-update
+    - if [[ "$DEPENDENCIES" == "" ]]; then composer update; fi
+    - if [[ "$DEPENDENCIES" == "low" ]]; then composer update --prefer-lowest; fi
 
 script:
     - ./bin/bldr run default

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
           env: DEPENDENCIES=low
 
 before_script:
+    - composer selfupdate
     - composer require satooshi/php-coveralls:dev-master --no-update
     - if [[ "$DEPENDENCIES" == "" ]]; then composer update; fi
     - if [[ "$DEPENDENCIES" == "low" ]]; then composer update --prefer-lowest; fi

--- a/composer.json
+++ b/composer.json
@@ -4,24 +4,22 @@
     "require":      {
         "php":                          ">=5.4",
         "bldr-io/composer-plugin":      "~1.0.4",
-        "dflydev/embedded-composer":    "dev-master@dev",
-        "composer/composer":            "dev-master@dev",
-        "symfony/console":              "~2.6",
-        "symfony/config":               "~2.6",
-        "symfony/yaml":                 "~2.6",
-        "symfony/dependency-injection": "~2.6",
-        "symfony/expression-language":  "~2.6",
-        "symfony/event-dispatcher":     "~2.6",
-        "symfony/process":              "~2.6",
+        "dflydev/embedded-composer":    "dev-master",
+        "composer/composer":            "dev-master",
+        "symfony/console":              "~2.3",
+        "symfony/config":               "~2.3",
+        "symfony/yaml":                 "~2.3",
+        "symfony/dependency-injection": "~2.3",
+        "symfony/expression-language":  "~2.3",
+        "symfony/event-dispatcher":     "~2.3",
+        "symfony/process":              "~2.3",
         "zendframework/zend-json":      "~2.3",
         "swiftmailer/swiftmailer":      "~5.3",
-        "bldr-io/frontend-block":       "~2.0.0@dev",
-        "richthegeek/phpsass":          "dev-master",
-        "bldr-io/remote-block":         "~2.0",
-        "yosymfony/toml":               "~0.2"
+        "yosymfony/toml":               "~0.2@dev"
     },
     "suggest":      {
-        "bldr-io/frontend-block": "Allows for managing front end compiling and minification"
+        "bldr-io/frontend-block": "Allows for managing front end compiling and minification",
+        "bldr-io/remote-block": "Allows to execute tasks on a remote server"
     },
     "require-dev":  {
         "matthiasnoback/symfony-service-definition-validator": "~1.1",


### PR DESCRIPTION
* Use faster docker based environment (`sudo: false`)
* Cache the composer dists (that's why `--prefer-source` is removed)
* Include a test for the lowest dependencies (this isn't 100%, as it is checking against 5.4.36, while you claim to support 5.4.0. Unfortuantely, Travis does only have 5.4.36...)