### PR TITLE
Fixed bug introduced in PR #150

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -186,7 +186,7 @@ EOF;
      */
     private function buildContainer(InputInterface $input, OutputInterface $output)
     {
-        $nonContainerCommands = ['install', 'update', 'dumpautoload', 'help'];
+        $nonContainerCommands = ['blocks-install', 'blocks-update', 'blocks-dumpautoload', 'help'];
 
         if (in_array($input->getFirstArgument(), $nonContainerCommands)) {
             return;


### PR DESCRIPTION
The prefix "blocks-" was added for blocks install, update and dump-autoload, see issue #149